### PR TITLE
Accept Query and Mutation root names as args

### DIFF
--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -1,4 +1,6 @@
 import axios from 'axios';
+import Insomnia from './insomnia/insomnia';
+import Postman from './postman/postman';
 
 const fs = require('fs');
 const
@@ -99,7 +101,7 @@ const
 
     `;
 
-const convert = async function (url: string, converter: string, headers: Array<string>) {
+const convert = async function (url: string, converter: string, rootQueryName: string, rootMutationName: string, headers: Array<string>) {
     let requestHeaders = {};
     headers.forEach(header => {
         const [key, value] = header.split(':');
@@ -110,8 +112,8 @@ const convert = async function (url: string, converter: string, headers: Array<s
 
     try {
         let response = await getSchema(url, instrospectionQuery, requestHeaders);
-        const c = Object.create(formatConverter.default.prototype)
-        let data = c.convert(response.data, url)
+        const converter: Insomnia | Postman = Object.create(formatConverter.default.prototype)
+        let data = converter.convert(response.data, url, rootQueryName, rootMutationName)
         fs.writeFileSync('export.json', data);
         console.log("File saved to export.json");
     } catch (err) {

--- a/src/exporters/insomnia/insomnia.ts
+++ b/src/exporters/insomnia/insomnia.ts
@@ -3,18 +3,18 @@ import { Root, RequestGroup, Request, RequestBody } from './types';
 const _ = require('lodash');
 
 class Insomnia {
-    convert(schema: any, url: string): string {
+    convert(schema: any, url: string, rootQueryName: string, rootMutationName: string): string {
         let rootExport = new Root;
         const types = schema.data.__schema.types;
-        let type: any;
         let graphQLRequestsGroup = new RequestGroup(url);
         rootExport.addResource(graphQLRequestsGroup);
+
         types.forEach(type => {
-            if (type.name == "RootQueryType" || type.name == "RootMutationType") {
+            if (type.name == rootQueryName || type.name == rootMutationName) {
                 let requestGroup = new RequestGroup(type.name)
                 requestGroup.parentId = graphQLRequestsGroup._id;
                 rootExport.addResource(requestGroup);
-                let query: any;
+
                 type.fields.forEach(query => {
                     let request = new Request(query.name);
                     request.url = url
@@ -27,12 +27,12 @@ class Insomnia {
                         returnFields = this.buildReturnFields(returnType);
                     }
 
-                    if (query.type.ofType != null) {
+                    if (query.type.ofType != null && query.type.ofType.kind !== "LIST") {
                         returnType = _.find(types, ['name', query.type.ofType.name]);
                         returnFields = this.buildReturnFields(returnType);
                     }
 
-                    let schemaType = type.name == "RootQueryType" ? "query" : "mutation";
+                    let schemaType = type.name == rootQueryName ? "query" : "mutation";
                     request.body = this.buildRequestText(schemaType, query, returnFields);
                     rootExport.addResource(request);
                 })

--- a/src/exporters/postman/postman.ts
+++ b/src/exporters/postman/postman.ts
@@ -4,20 +4,20 @@ import Variable from './types/variable';
 const _ = require('lodash');
 
 class Postman {
-    convert(schema: any, url: string) {
+    convert(schema: any, url: string, rootQueryName: string, rootMutationName: string): string {
         let collection = new Collection;
         collection.info.name = url;
         let baseUrlVar = new Variable('base_url', url);
         collection.addVariable(baseUrlVar);
         const types = schema.data.__schema.types;
-        let type: any;
+
 
         types.forEach(type => {
-            if (type.name == "RootQueryType" || type.name == "RootMutationType") {
+            if (type.name == rootQueryName || type.name == rootMutationName) {
                 let folder = new Folder(type.name);
-                let query: any;
+
                 type.fields.forEach(query => {
-                    let schemaType = type.name == "RootQueryType" ? "query" : "mutation";
+                    let schemaType = type.name == rootQueryName ? "query" : "mutation";
                     let returnType;
                     let returnFields;
 
@@ -26,7 +26,7 @@ class Postman {
                         returnFields = Utils.buildReturnFields(returnType);
                     }
 
-                    if (query.type.ofType != null) {
+                    if (query.type.ofType != null && query.type.ofType.kind !== "LIST") {
                         returnType = _.find(types, ['name', query.type.ofType.name]);
                         returnFields = Utils.buildReturnFields(returnType);
                     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { convert } from './exporters'
 const chalk = require('chalk');
 const clear = require('clear');
 const figlet = require('figlet');
+const yargs = require('yargs');
 
 clear();
 console.log(
@@ -12,7 +13,6 @@ console.log(
     )
 );
 
-const yargs = require('yargs');
 const argv = yargs
     .option('url', {
         description: 'the graphql server root url',
@@ -25,6 +25,16 @@ const argv = yargs
         type: 'string',
         choices: ['insomnia', 'postman']
     })
+    .option('query-name', {
+        description: 'the name of your root query field',
+        alias: 'q',
+        type: 'string'
+    })
+    .option('mutation-name', {
+        description: 'the name of your root mutation field',
+        alias: 'm',
+        type: 'string'
+    })
     .option('custom-headers', {
         description: 'Custom headers to pass with the request to the graphql server, should be passed in form "header-name:header-value"',
         alias: 'H',
@@ -36,4 +46,30 @@ const argv = yargs
     .alias('help', 'h')
     .argv;
 
-convert(argv.url, argv.format, argv['custom-headers']);
+if (argv['query-name'] == null) {
+    const defaultValue = "RootQueryType"
+    console.info(
+        chalk.cyan(
+            'Argument' + chalk.italic(' query-name ') +
+            'was not supplied. Using default value: ' +
+            chalk.italic.bgCyan.black(` ${defaultValue} `)
+        )
+    )
+
+    argv['query-name'] = defaultValue
+
+}
+
+if (argv['mutation-name'] == null) {
+    const defaultValue = "RootMutationType"
+    console.info(
+        chalk.cyan(
+            'Argument' + chalk.italic(' mutation-name ') +
+            'was not supplied. Using default value: ' +
+            chalk.italic.bgCyan.black(` ${defaultValue} `)
+        )
+    )
+    argv['mutation-name'] = defaultValue
+}
+
+convert(argv.url, argv.format, argv['query-name'], argv['mutation-name'], argv['custom-headers']);

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,4 +72,4 @@ if (argv['mutation-name'] == null) {
     argv['mutation-name'] = defaultValue
 }
 
-convert(argv.url, argv.format, argv['query-name'], argv['mutation-name'], argv['custom-headers']);
+convert(argv['url'], argv['format'], argv['query-name'], argv['mutation-name'], argv['custom-headers']);


### PR DESCRIPTION
Greetings from Brazil! 🇧🇷  👋 

I tried using your script to generate a postman collection, but the script failed since my `Query` and `Mutation` root fields had names different from `RootQueryType` and `RootMutationType`, respectively.

Therefore I added these changes so the Query and Mutation root field names can be parameterized