### PR TITLE
Fix more types

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   verbose: true,
+  modulePathIgnorePatterns: ["<rootDir>/dist/"]
 };

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "yargs": "^13.3.0"
   },
   "devDependencies": {
+    "@types/graphql": "^14.5.0",
     "@types/jest": "^24.0.15",
-    "@types/lodash": "^4.14.136",
+    "@types/lodash": "^4.14.162",
+    "@types/lodash.find": "^4.6.6",
     "@types/node": "^12.6.8",
     "ts-jest": "^25.4.0",
     "ts-node": "^8.3.0",

--- a/src/exporters/index.ts
+++ b/src/exporters/index.ts
@@ -102,7 +102,7 @@ const
     `;
 
 const convert = async function (url: string, converter: string, rootQueryName: string, rootMutationName: string, headers: Array<string>) {
-    let requestHeaders = {};
+    let requestHeaders: Record<string, string> = {};
     headers.forEach(header => {
         const [key, value] = header.split(':');
         requestHeaders[key.trim()] = value.trim();

--- a/src/exporters/insomnia/insomnia.ts
+++ b/src/exporters/insomnia/insomnia.ts
@@ -1,16 +1,17 @@
-import axios from 'axios';
 import { Root, RequestGroup, Request, RequestBody } from './types';
-const _ = require('lodash/collection');
+import find = require('lodash/find');
+import type { IntrospectionField, IntrospectionSchema, IntrospectionType } from 'graphql'
+import Utils from "../../utils";
 
 class Insomnia {
     convert(schema: any, url: string, rootQueryName: string, rootMutationName: string): string {
         let rootExport = new Root;
-        const types = schema.data.__schema.types;
+        const types: IntrospectionSchema["types"] = schema.data.__schema.types;
         let graphQLRequestsGroup = new RequestGroup(url);
         rootExport.addResource(graphQLRequestsGroup);
 
         types.forEach(type => {
-            if (type.name == rootQueryName || type.name == rootMutationName) {
+            if (Utils.isRootQuery(type, rootQueryName) || Utils.isRootMutation(type, rootMutationName)) {
                 let requestGroup = new RequestGroup(type.name)
                 requestGroup.parentId = graphQLRequestsGroup._id;
                 rootExport.addResource(requestGroup);
@@ -19,17 +20,17 @@ class Insomnia {
                     let request = new Request(query.name);
                     request.url = url
                     request.parentId = requestGroup._id;
-                    let returnType;
-                    let returnFields;
+                    let returnType: IntrospectionType;
+                    let returnFields: string = "";
 
-                    if (query.type.name != null) {
-                        returnType = _.find(types, ['name', query.type.name]);
-                        returnFields = this.buildReturnFields(returnType);
+                    if ("name" in query.type && query.type.name != null) {
+                        returnType = find(types, ['name', query.type.name]) as IntrospectionType;
+                        returnFields = Utils.buildReturnFields(returnType);
                     }
 
-                    if (query.type.ofType != null && query.type.ofType.kind !== "LIST") {
-                        returnType = _.find(types, ['name', query.type.ofType.name]);
-                        returnFields = this.buildReturnFields(returnType);
+                    if ("ofType" in query.type && query.type.ofType != null && query.type.ofType.kind !== "LIST") {
+                        returnType = find(types, ['name', query.type.ofType.name]) as IntrospectionType;
+                        returnFields = Utils.buildReturnFields(returnType);
                     }
 
                     let schemaType = type.name == rootQueryName ? "query" : "mutation";
@@ -42,67 +43,14 @@ class Insomnia {
         return data;
     }
 
-    buildRequestText(schemaType: string, query: any, returnFields: string) : RequestBody {
-        let endpointArgs = this.buildEndpointArgs(query.args);
-        let queryArgs = this.buildQueryArgs(query.args);
+    buildRequestText(schemaType: string, query: IntrospectionField, returnFields: string) : RequestBody {
+        let endpointArgs = Utils.buildEndpointArgs(query.args);
+        let queryArgs = Utils.buildQueryArgs(query.args);
         let bodyText =  schemaType+" "+queryArgs+" { \n\t"+query.name+" "+endpointArgs+" {\n"+returnFields+"\n\t} \n}"
-        let variables = this.buildVariables(query.args);
+        let variables = Utils.buildVariables(query.args);
         let requestBody: RequestBody = new RequestBody(bodyText, variables);
         return requestBody
     }
-
-    buildQueryArgs(args : any[]) : string {
-        if (args.length == 0) {
-            return '';
-        }
-
-        let argString = `(`;
-        for (let i = 0; i < args.length; i++) {
-            if (args[i].type.kind == 'LIST') {
-                argString += `$${args[i].name}: [${args[i].type.ofType.name}]`
-            } else {
-                argString += `$${args[i].name}: ${args[i].type.name}`
-            }
-            if (i != args.length - 1) {
-                argString += ','
-            }
-        }
-        argString += ')'
-        return argString;
-    }
-
-    buildEndpointArgs(args: any[]) : string {
-        if (args.length == 0) {
-            return '';
-        }
-
-        let argString = `(`;
-        for (let i = 0; i < args.length; i++) {
-            argString += `${args[i].name}: $${args[i].name}`
-            if (i != args.length - 1) {
-                argString += ','
-            }
-        }
-        argString += ')'
-        return argString;
-    }
-
-    buildVariables(args: any[]) : string {
-        let variables = {};
-        for (let i = 0; i < args.length; i++) {
-            variables[args[i].name] = '';
-        }
-        return JSON.stringify(variables);
-    }
-
-    buildReturnFields(returnType: any) : string {
-
-        let returnValues: string = '';
-        returnType.fields.forEach((field, idx) => {
-            returnValues += '\t\t' + (field.name + (idx == returnType.fields.length - 1 ? '' : '\n'));
-        })
-        return returnValues
-    }
 }
 
-export default Insomnia ;
+export default Insomnia;

--- a/src/exporters/postman/types/request.ts
+++ b/src/exporters/postman/types/request.ts
@@ -17,15 +17,16 @@ export interface PostmanRequestBody {
 }
 
 class Request {
-    url: string
-    method: HTTPMethod
-    description: Maybe<string>;
-    headers: Array<Header>
-    body: PostmanRequestBody
-
-    constructor({ url, method, headers = [], body = defaultBody }) {
+    constructor(
+        public url: string,
+        public method: HTTPMethod,
+        public description?: Maybe<string>,
+        public headers: Array<Header> = [],
+        public body: PostmanRequestBody = defaultBody,
+    ) {
         this.url = url;
         this.method = method;
+        this.description = description;
         this.headers = headers;
         this.body = body;
     }

--- a/src/tests/insomnia.test.ts
+++ b/src/tests/insomnia.test.ts
@@ -1,9 +1,0 @@
-import Insomnia from '../exporters/insomnia/insomnia'
-
-describe('Test buildQueryArgs', function() {
-    it('returns empty string for empty arguments', function () {
-        let insomnia = new Insomnia();
-        let result = insomnia.buildQueryArgs([]);
-        expect(result).toBe("");
-    });
-});

--- a/src/tests/utils.test.ts
+++ b/src/tests/utils.test.ts
@@ -1,0 +1,8 @@
+import Utils from "../utils";
+
+describe('buildQueryArgs', function () {
+    it('returns empty string for empty arguments', function () {
+        let result = Utils.buildQueryArgs([]);
+        expect(result).toBe("");
+    });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,8 @@
+import { IntrospectionInputValue, IntrospectionObjectType, IntrospectionType } from "graphql";
+
 class Utils {
 
-    static buildQueryArgs(args : any[]) : string {
+    static buildQueryArgs(args : readonly any[]) : string {
         if (args.length == 0) {
             return '';
         }
@@ -20,7 +22,7 @@ class Utils {
         return argString;
     }
 
-    static buildEndpointArgs(args: any[]) : string {
+    static buildEndpointArgs(args: readonly IntrospectionInputValue[]) : string {
         if (args.length == 0) {
             return '';
         }
@@ -36,21 +38,31 @@ class Utils {
         return argString;
     }
 
-    static buildVariables(args: any[]) : string {
-        let variables = {};
+    static buildVariables(args: readonly IntrospectionInputValue[]) : string {
+        let variables: Record<string, string> = {};
         for (let i = 0; i < args.length; i++) {
             variables[args[i].name] = '';
         }
         return JSON.stringify(variables);
     }
 
-    static buildReturnFields(returnType: any) : string {
+    static buildReturnFields(returnType: IntrospectionType) : string {
 
         let returnValues: string = '';
-        returnType.fields.forEach((field, idx) => {
-            returnValues += '\t\t' + (field.name + (idx == returnType.fields.length - 1 ? '' : '\n'));
-        })
-        return returnValues
+        if ("fields" in returnType) {
+            returnType.fields.forEach((field, idx) => {
+                returnValues += '\t\t' + (field.name + (idx == returnType.fields.length - 1 ? '' : '\n'));
+            })
+        }
+        return returnValues;
+    }
+
+    static isRootQuery(type: IntrospectionType, rootQueryName: string): type is IntrospectionObjectType {
+        return type.name === rootQueryName;
+    }
+
+    static isRootMutation(type: IntrospectionType, rootMutationName: string): type is IntrospectionObjectType {
+        return type.name === rootMutationName;
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,9 +4,9 @@
     "incremental": true,
     "isolatedModules": true,
     "moduleResolution": "node",
+    "noEmitOnError": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": false,
     "outDir": "./dist",
     "strict": true,
     "target": "es3"


### PR DESCRIPTION
Follow-up on PR #10. 

~Please Review #10 before this one. Click [here](https://github.com/emilianoLeite/graphql-export/pull/2/files) to check the actual difference between this PR and #10~

I tried my best to not change any runtime code, but please double-check and test locally to ensure that everything is working as expected

But, regardless, I know these are some fairly complex Typescript changes, so I am more than happy to answer any questions.

I tested both formats locally and the export was generated successfully, but I noticed that queries with variables in Insomnia are genereted in the following format:
```gql
query ($id: null) {
  ...
}
```

where it should be

```diff
- query ($id: null) {
+ query ($id: ID) {
  ...
}
```
is this a known problem?

---

In the following PRs, I intend to create some automated tests to ensure that future refactorings are easier 😅 

