### PR TITLE
fix(Postman): Generate a new defaultBody for every instantiation

### DIFF
--- a/src/exporters/postman/types/folder.ts
+++ b/src/exporters/postman/types/folder.ts
@@ -4,18 +4,18 @@ import Item from './item';
 class Folder {
     name: string = "";
     description: string = "";
-    variable: Array<Variable> = [];
-    item: Array<Item> = [];
+    variables: Array<Variable> = [];
+    items: Array<Item> = [];
 
     constructor (name: string) {
         this.name = name;
     }
     addVariable (variable: Variable) {
-        this.variable.push(variable);
+        this.variables.push(variable);
     }
 
     addItem (item: Item) {
-        this.item.push(item);
+        this.items.push(item);
     }
 }
 

--- a/src/exporters/postman/types/request.ts
+++ b/src/exporters/postman/types/request.ts
@@ -1,12 +1,12 @@
 import Header from "./header";
 
-const defaultBody = {
+const defaultBody = () => ({
     mode: 'graphql',
     graphql: {
         query: '',
         variables: '',
     }
-} as const
+} as const)
 
 export interface PostmanRequestBody {
     mode: 'graphql';
@@ -22,7 +22,7 @@ class Request {
         public method: HTTPMethod,
         public description?: Maybe<string>,
         public headers: Array<Header> = [],
-        public body: PostmanRequestBody = defaultBody,
+        public body: PostmanRequestBody = defaultBody(),
     ) {
         this.url = url;
         this.method = method;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "isolatedModules": true,
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
Hello again 👋 

While working on getting some automated tests set up (you can check the final result progress [here](https://github.com/oshosanya/graphql-export/pull/15)), I noticed that I introduced a bug in Postman's `Request` class in one of my previous changes (#10  specifically).
The bug causes every instance of that class to share the same `body` property, since that object was being created outside the instantiation process 🤦 .

This caused all generated Postman requests to contain the exact same request body.

## Example

### Bug
```json
{
    "variable": [],
    "name": "rootQuery1",
    "request": {
        "url": "{{base_url}}",
        "method": "POST",
        "headers": [],
        "body": {
            "mode": "graphql",
            "graphql": { 👇 same value for all requests
                "query": "mutation ($var2: null,$var3: null) { \n\trootMutation1 (var2: $var2,var3: $var3) {\n\t\tsuccess\n\t\tcode\n\t\terrors\n\t} \n}",
                "variables": "{\"var2\":\"\",\"var3\":\"\"}"
            }
        }
    }
},
{
    "variable": [],
    "name": "rootQuery2",
    "request": {
        "url": "{{base_url}}",
        "method": "POST",
        "headers": [],
        "body": {
            "mode": "graphql",
            "graphql": { 👇 same value for all requests
                "query": "mutation ($var2: null,$var3: null) { \n\trootMutation1 (var2: $var2,var3: $var3) {\n\t\tsuccess\n\t\tcode\n\t\terrors\n\t} \n}", 
                "variables": "{\"var2\":\"\",\"var3\":\"\"}"
            }
        }
    }
}
```
### Bug fixed
```json
{
    "variable": [],
    "name": "rootQuery1",
    "request": {
        "url": "{{base_url}}",
        "method": "POST",
        "headers": [],
        "body": {
            "mode": "graphql",
            "graphql": { 👇 fixed
                "query": "query ($var1: null) { \n\trootQuery1 (var1: $var1) {\n\t\tid\n\t\tarray\n\t\trelation\n\t} \n}",
                "variables": "{\"var1\":\"\"}"
            }
        }
    }
},
{
    "variable": [],
    "name": "rootQuery2",
    "request": {
        "url": "{{base_url}}",
        "method": "POST",
        "headers": [],
        "body": {
            "mode": "graphql",
            "graphql": { 👇  fixed
                "query": "query  { \n\trootQuery2  {\n\t\tid\n\t\tarray\n\t\trelation\n\t} \n}",
                "variables": "{}"
            }
        }
    }
}
```



----

As a side note, I checked my Hacktoberfest progress the other day and was really confused, because it indicated that I had `0` hacktobefest-compliant PR's 😱 . After a double-check, I saw that you unfortunately made a typo when adding the topic (`haktoberfest` instead of `hacktoberfest` 😓 ). 

So I would really appreciate if could retroactively add the label `hacktoberfest-accepted` to my merged PRs, since I don't know that fixing the topic now will validate my previous PRs
- https://github.com/oshosanya/graphql-export/pull/8
- https://github.com/oshosanya/graphql-export/pull/10
- https://github.com/oshosanya/graphql-export/pull/11

Thanks in advance 🙏 
